### PR TITLE
Ensure a uniform width for both the header and the content

### DIFF
--- a/src/orasecom/templates/geonode-mapstore-client/snippets/topbar.html
+++ b/src/orasecom/templates/geonode-mapstore-client/snippets/topbar.html
@@ -144,4 +144,9 @@
     color: #BB8E3E;
     border: var(--orasecom-topbar);
   }
+  .gn-menu-container {
+    max-width: 1440px;
+    position: relative;
+    width: 100%;
+  }
 </style>


### PR DESCRIPTION
For #13

### Before
<img width="1493" alt="Screenshot 2025-01-10 at 12 53 09" src="https://github.com/user-attachments/assets/4a227cda-5249-4d65-acb3-e648cc2a11cc" />

### After
<img width="1476" alt="Screenshot 2025-01-10 at 12 52 58" src="https://github.com/user-attachments/assets/3afac192-dc2d-4778-9f46-499f4179c9ab" />
